### PR TITLE
Bugfix IE11, known issue with flex-direction: column

### DIFF
--- a/app/views/styles/component/_iefix.scss
+++ b/app/views/styles/component/_iefix.scss
@@ -1,0 +1,13 @@
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+    .form-footer__content__main-controls,
+    .main,
+    .main .paper,
+    .paper > form {
+        // bugfix for display:flex with parent min-height
+        // see: http://philipwalton.com/articles/normalizing-cross-browser-flexbox-bugs/
+        -ms-flex-basis: auto;
+        flex-basis: auto;
+        -ms-flex-shrink: 0;
+        flex-shrink: 0;
+    }
+}

--- a/app/views/styles/theme-formhub/theme-formhub.scss
+++ b/app/views/styles/theme-formhub/theme-formhub.scss
@@ -35,3 +35,6 @@
 @import "form_formhub";
 @import "../component/form_header";
 @import "../component/form_footer";
+
+// ie patch
+@import "../component/iefix";

--- a/app/views/styles/theme-grid/theme-grid.scss
+++ b/app/views/styles/theme-grid/theme-grid.scss
@@ -35,3 +35,6 @@
 @import "form-grid";
 @import "../component/form_header";
 @import "../component/form_footer";
+
+// ie patch
+@import "../component/iefix";

--- a/app/views/styles/theme-kobo/theme-kobo.scss
+++ b/app/views/styles/theme-kobo/theme-kobo.scss
@@ -35,3 +35,6 @@
 @import "../theme-formhub/form_formhub";
 @import "../component/form_header";
 @import "../component/form_footer";
+
+// ie patch
+@import "../component/iefix";

--- a/app/views/styles/theme-oc/theme-oc.scss
+++ b/app/views/styles/theme-oc/theme-oc.scss
@@ -37,3 +37,6 @@
 @import "../theme-formhub/form_formhub";
 @import "../component/form_header";
 @import "../component/form_footer";
+
+// ie patch
+@import "../component/iefix";

--- a/app/views/styles/theme-plain/theme-plain.scss
+++ b/app/views/styles/theme-plain/theme-plain.scss
@@ -32,3 +32,6 @@
 @import "form_plain";
 @import "../component/form_header";
 @import "../component/form_footer";
+
+// ie patch
+@import "../component/iefix";


### PR DESCRIPTION
`flex-direction: column` ignores `min-height`,
see: https://connect.microsoft.com/IE/feedback/details/802625/min-height-and-flexbox-flex-direction-column-dont-work-together-in-ie-10-11-preview

the proposed solution is to use `flex-shrink: 0`,
see: http://philipwalton.com/articles/normalizing-cross-browser-flexbox-bugs/