### PR TITLE
Fix image label for input in a form not clickable in IE11

### DIFF
--- a/app/views/styles/component/_iefix.scss
+++ b/app/views/styles/component/_iefix.scss
@@ -15,4 +15,10 @@
     .form__loader {
         min-height: 200px;
     }
+
+    .option-wrapper > label img{
+        // http://stackoverflow.com/questions/20198137/image-label-for-input-in-a-form-not-clickable-in-ie11
+        display: inline!important;
+        pointer-events: none;
+    }
 }


### PR DESCRIPTION
JIRA ticket: OC-7079

@kkrumlian @MartijnR please review, thanks

Video demoing the fix: https://jira.openclinica.com/secure/attachment/33266/33266_fix-OC-7079.ogv