### PR TITLE
(7113-related) Show correct error message to the user on backend validation failure

### DIFF
--- a/public/js/src/module/connection.js
+++ b/public/js/src/module/connection.js
@@ -157,11 +157,12 @@ function _uploadBatch( recordBatch ) {
                     reject( result );
                 }
             } )
-            .fail( function( jqXHR, textStatus ) {
+            .fail( function( jqXHR, textStatus) {
                 // TODO: extract message from XML response?
                 reject( {
-                    status: jqXHR.status
-                        // message: textStatus
+                    status: jqXHR.status,
+                    // need message for spesific error
+                    message: jqXHR.responseText ? jqXHR.responseText : undefined
                 } );
                 if ( jqXHR.status === 0 ) {
                     _setOnlineStatus( false );

--- a/public/js/src/module/controller-webform.js
+++ b/public/js/src/module/controller-webform.js
@@ -260,7 +260,10 @@ function _submitRecord() {
                     here: authLink
                 } ), t( 'alert.submissionerror.heading' ) );
             } else {
-                gui.alert( gui.getErrorResponseMsg( result.status ), t( 'alert.submissionerror.heading' ) );
+                if ( result.status === 406 )
+                    gui.alert(  result.message  , t( 'alert.submissionerror.heading' ) );    
+                else
+                    gui.alert( gui.getErrorResponseMsg( result.status ), t( 'alert.submissionerror.heading' ) );
             }
         } );
 }


### PR DESCRIPTION
https://jira.openclinica.com/browse/OC-7113
That ticket suggests a validator for "max length limit". But upon checking, the validator is already there -- it's the error message ("max length exceeded") that's not displayed correctly so the user doesn't know that the input is too long.

This PR fixes that (so the error message delivered correctly to the user).

fix demo video: https://jira.openclinica.com/secure/attachment/33822/OC-7113.ogv