### PR TITLE
Update from upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+[Unreleased]
+---------------------
+##### Added
+- Image Map select widget.
+
 [1.45.2] - 2017-05-09
 ---------------------
 ##### Added

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "csurf": "1.9.x",
         "db.js": "0.15.0",
         "debug": "2.x.x",
-        "enketo-core": "4.32.1",
+        "enketo-core": "https://github.com/enketo/enketo-core.git#4b90284",
         "enketo-transformer": "1.16.0",
         "enketo-xpathjs-oc": "https://github.com/openclinica/enketo-xpathjs-oc.git#44b0e5a",
         "express": "4.x.x",

--- a/public/js/src/module/widgets.js
+++ b/public/js/src/module/widgets.js
@@ -23,6 +23,7 @@ var widgets = [
     require( '../../../../node_modules/enketo-core/src/widget/analog-scale/analog-scalepicker' ),
     require( '../../../../node_modules/enketo-core/src/widget/big-image/image-viewer' ),
     require( '../../../../node_modules/enketo-core/src/widget/comment/commentwidget' ),
+    require( '../../../../node_modules/enketo-core/src/widget/image-map/image-map' ),
     require( '../../../../public/widget/discrepancy-note/dn-widget' ),
 ];
 


### PR DESCRIPTION
Hi @MartijnR 

As a first step, I'd like enketo-express-oc and enketo-express to be in sync, so here I'm merging upstream changes. There's merge conflict:
- Upstream added imagemap widget
- enketo-express-oc added DN widget

Fixed by adding imagemap widget to enketo-express-oc too, since there's no harm in having it even if it's not used by OpenClinica (CMIIW).

Also, will there be any difference between kobotoolbox's enketo-express and enketo's enketo-express? Or will they always be same?

And about pinning dependency to the specific commit "https://github.com/enketo/enketo-core.git#4b90284", it doesn't "feel right" to me since that means we won't get bugfixes from newer enketo-core. If I want to make it work with npm-published enketo-core, what is your recommendation?


