### PR TITLE
update: OC: DN history (reduce vertical space and make both column vertically aligned)

### DIFF
--- a/app/views/styles/component/_print-oc.scss
+++ b/app/views/styles/component/_print-oc.scss
@@ -31,20 +31,46 @@
         }
     }
 
-    .or-comment-widget__content__history__row__start__username {
-        border: none;
-        height: 25px;
-        line-height: 25px;
+    .question.or-appearance-dn.printified[role="comment"] {
+        padding-top: 5px;
+        padding-bottom: 10px;
     }
 
-    .or-comment-widget__content__history__row__main {
-        border: none;
-        padding: 0;
+}
+
+.dn-temp-print {
+    margin-top: 5px;
+    margin-bottom: 0px;
+
+    .or-comment-widget__content__history__row, .or-comment-widget__content__history__row.audit {
+        margin-bottom: 5px;
+
+        &:not(:last-child) {
+            margin-bottom: 2px;
+        }
+
+        .or-comment-widget__content__history__row__start__username {
+            border: none;
+            height: 18px;
+            line-height: 18px;
+        }
+
+        .or-comment-widget__content__history__row__main {
+            border: none;
+            padding: 0;
+        }
+
+        .or-comment-widget__content__history__row__main--audit {
+            padding-top: 0;
+            height: 35px;
+        }
+
+        .or-comment-widget__content__history__row__main:before, .or-comment-widget__content__history__row__main:after {
+            opacity: 0;
+        }
+
     }
 
-    .or-comment-widget__content__history__row__main:before, .or-comment-widget__content__history__row__main:after {
-        opacity: 0;
-    }
 }
 
 .btn-dn {


### PR DESCRIPTION
#275 
Paul's feedback : 

> Can you update this further to remove the additional whitespace between entries? We want this to be as efficient with space as it can be so that these printed forms are not filled with extra pages showing query and history information.
From your screenshot, it looks like excess space can still be removed from above each entry.
Also, it doesn't look like the left column (name and timestamp) and is vertically aligned with the right column (query/history text and additional query information). Can you update it so that these are aligned and we can be sure we are optimizing space?

Preview :
![Screenshot from 2019-12-30 20-27-45](https://user-images.githubusercontent.com/13865076/71612160-6de76400-2bd9-11ea-9c24-dd6b47c9c834.png)

