### PR TITLE
fixed: OC: Page break is at end of DN history (and not in middle)#266

### DIFF
--- a/app/views/styles/component/_print-oc.scss
+++ b/app/views/styles/component/_print-oc.scss
@@ -31,53 +31,80 @@
         }
     }
 
-    .question.or-appearance-dn.printified[role="comment"] {
-        padding-top: 5px;
-        padding-bottom: 10px;
+    .question.or-appearance-dn.printified {
+        
+        &[role="comment"] {
+            padding-top: 5px;
+            padding-bottom: 10px;
+        }
     }
 
+    &.pages.or {
+
+        [role="page"].current:not(.question) {
+
+            .or-group:not(.disabled),
+            .or-group-data:not(.disabled),
+            .or-repeat:not(.disabled) {
+                display: block;
+            }
+        }
+    }
 }
+
 
 .dn-temp-print {
     margin-top: 5px;
     margin-bottom: 0px;
 
-    .or-comment-widget__content__history__row, .or-comment-widget__content__history__row.audit {
-        margin-bottom: 5px;
+    .or-comment-widget {
+        &__content__history__row,
+        &.audit {
+            margin-bottom: 5px;
+            display: table;
+            border-collapse: separate;
+            border-spacing: 15px 0;
 
-        &:not(:last-child) {
-            margin-bottom: 2px;
-        }
+            &:not(:last-child) {
+                margin-bottom: 2px;
+            }
 
-        .or-comment-widget__content__history__row__start__username {
-            border: none;
-            height: 18px;
-            line-height: 18px;
-        }
+            &__start {
+                display: table-cell;
 
-        .or-comment-widget__content__history__row__main {
-            border: none;
-            padding: 0;
-        }
-
-        .or-comment-widget__content__history__row__main--audit {
-            padding: 0 20px 0 10px;
-
-            .or-comment-widget__content__history__row__main__comment {
-                
-                .or-comment-widget__content__history__row__main__comment__meta {
-                    display: none;
+                &__username {
+                    border: none;
+                    height: 18px;
+                    line-height: 18px;    
                 }
 
             }
-        }
 
-        .or-comment-widget__content__history__row__main:before, .or-comment-widget__content__history__row__main:after {
-            opacity: 0;
-        }
+            &__main {
+                border: none;
+                padding: 0;
+                display: table-cell;
 
+                &--audit {
+                    padding: 0 20px 0 10px;
+
+                    .or-comment-widget__content__history__row__main__comment__meta {
+                        display: none;
+                    }
+
+                }
+
+                &:before,
+                &:after {
+                    opacity: 0;
+                }
+
+                &__comment__meta {
+                    display: inline-block; // 'display: block' result in some margin on print preview
+                }
+            }
+        }
     }
-
 }
 
 .btn-dn {


### PR DESCRIPTION
#266 [OC-11750](https://jira.openclinica.com/browse/OC-11750)
- remove display: flex and use display: block, table and table-cell

here is the preview : 
[Vital SignsA4.pdf](https://github.com/OpenClinica/enketo-express-oc/files/4072195/Vital.SignsA4.pdf)
[Vital SignsLetter.pdf](https://github.com/OpenClinica/enketo-express-oc/files/4072196/Vital.SignsLetter.pdf)

