### PR TITLE
fixed: OC: overlapping username and remove fixed height on history(role='comment')

### DIFF
--- a/app/views/styles/component/_print-oc.scss
+++ b/app/views/styles/component/_print-oc.scss
@@ -36,6 +36,7 @@
         &[role="comment"] {
             padding-top: 5px;
             padding-bottom: 10px;
+            height: 100% !important;
         }
     }
 
@@ -64,6 +65,7 @@
             display: table;
             border-collapse: separate;
             border-spacing: 15px 0;
+            page-break-inside: avoid;
 
             &:not(:last-child) {
                 margin-bottom: 2px;
@@ -75,7 +77,8 @@
                 &__username {
                     border: none;
                     height: 18px;
-                    line-height: 18px;    
+                    line-height: 18px;
+                    display: inline-block;
                 }
 
             }

--- a/app/views/styles/component/_print-oc.scss
+++ b/app/views/styles/component/_print-oc.scss
@@ -31,53 +31,80 @@
         }
     }
 
-    .question.or-appearance-dn.printified[role="comment"] {
-        padding-top: 5px;
-        padding-bottom: 10px;
+    .question.or-appearance-dn.printified {
+        
+        &[role="comment"] {
+            padding-top: 5px;
+            padding-bottom: 10px;
+        }
     }
 
+    &.pages.or {
+
+        [role="page"].current:not(.question) {
+
+            .or-group:not(.disabled),
+            .or-group-data:not(.disabled),
+            .or-repeat:not(.disabled) {
+                display: block;
+            }
+        }
+    }
 }
+
 
 .dn-temp-print {
     margin-top: 5px;
     margin-bottom: 0px;
 
-    .or-comment-widget__content__history__row, .or-comment-widget__content__history__row.audit {
-        margin-bottom: 5px;
+    .or-comment-widget {
+        &__content__history__row,
+        &.audit {
+            margin-bottom: 5px;
+            display: table;
+            border-collapse: separate;
+            border-spacing: 15px 0;
 
-        &:not(:last-child) {
-            margin-bottom: 2px;
-        }
+            &:not(:last-child) {
+                margin-bottom: 2px;
+            }
 
-        .or-comment-widget__content__history__row__start__username {
-            border: none;
-            height: 18px;
-            line-height: 18px;
-        }
+            &__start {
+                display: table-cell;
 
-        .or-comment-widget__content__history__row__main {
-            border: none;
-            padding: 0;
-        }
-
-        .or-comment-widget__content__history__row__main--audit {
-            padding: 0 20px 0 10px;
-
-            .or-comment-widget__content__history__row__main__comment {
-                
-                .or-comment-widget__content__history__row__main__comment__meta {
-                    display: none;
+                &__username {
+                    border: none;
+                    height: 18px;
+                    line-height: 18px;    
                 }
 
             }
-        }
 
-        .or-comment-widget__content__history__row__main:before, .or-comment-widget__content__history__row__main:after {
-            opacity: 0;
-        }
+            &__main {
+                border: none;
+                padding: 0;
+                display: table-cell;
 
+                &--audit {
+                    padding: 0 20px 0 10px;
+
+                    .or-comment-widget__content__history__row__main__comment__meta {
+                        display: none;
+                    }
+
+                }
+
+                &:before,
+                &:after {
+                    opacity: 0;
+                }
+
+                &__comment__meta {
+                    display: inline-block; // 'display: block' result in some margin on print preview
+                }
+            }
+        }
     }
-
 }
 
 .btn-dn {


### PR DESCRIPTION
#266  #282
 
- Fixed overlapping username by adding 'display: inline-block'
- Fixed overflowing content by removing fixed height 'height: 100% !important;' 

Have a problem with how to reproduce using form that has previously had data entered and is reopened on local so I'm not test it on that case yet.

preview: 
[Vital Signs-reproduce-error.pdf](https://github.com/OpenClinica/enketo-express-oc/files/4095775/Vital.Signs-reproduce-error.pdf)
[Vital Signs-fixed.pdf](https://github.com/OpenClinica/enketo-express-oc/files/4095777/Vital.Signs-fixed.pdf)

