### PR TITLE
changed: separated terser task for modern browser from outdated browsers

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -175,14 +175,13 @@ module.exports = grunt => {
                 args: [ 'grunt', 'mochaTest:all' ]
             }
         },
-        terser: { 
+        terser: {
             'default': {
                 options: {
                     // https://github.com/enketo/enketo-express/issues/72
                     keep_classnames: true,
                 },
                 files: bundles
-                    .concat( bundles.map( bundle => bundle.replace( '-bundle.', '-ie11-bundle.' ) ) )
                     .map( bundle => [ bundle.replace( '.js', '.min.js' ), [ bundle ] ] )
                     .reduce( ( o, [ key, value ] ) => {
                         o[ key ] = value;
@@ -198,7 +197,7 @@ module.exports = grunt => {
                     keep_fnames: true
                 },
                 files: bundles
-                    .concat( bundles.map( bundle => bundle.replace( '-bundle.', '-ie11-bundle.' ) ) )
+                    .map( bundle => bundle.replace( '-bundle.', '-ie11-bundle.' ) )
                     .map( bundle => [ bundle.replace( '.js', '.min.js' ), [ bundle ] ] )
                     .reduce( ( o, [ key, value ] ) => {
                         o[ key ] = value;


### PR DESCRIPTION
I changed the terser tasks to separate modern browsers from outdated browsers. The advantage is that:

* the outdated browsers do not hold back modern browsers creating a smaller build
* building will be faster

I checked modern browsers. If you could just double-check that I didn't break the outdated-browser build that would be great @theywa. If you don't have time until after Saturday just go ahead and merge into master if it looks good.

If you find an issue with this PR just leave it open. It is not critical.