### PR TITLE
fixed: OC: Text Multiline item with long values loads with widget condensed

### DIFF
--- a/widget/textarea/textarea.js
+++ b/widget/textarea/textarea.js
@@ -1,0 +1,48 @@
+import Widget from 'enketo-core/src/js/widget';
+import events from 'enketo-core/src/js/event';
+
+/**
+ * Auto-resizes textarea elements.
+ *
+ * @augments Widget
+ */
+class TextareaWidget extends Widget {
+    /**
+     * @type {string}
+     */
+    static get selector() {
+        return 'form';
+    }
+
+    _init() {
+        const textareas = this.element.querySelectorAll( 'textarea' );
+        this.defaultHeight = textareas[ 0 ] ? textareas[ 0 ].clientHeight : 20;
+        this.element.addEventListener( 'input', event => {
+            const el = event.target;
+            if ( el.nodeName.toLowerCase() === 'textarea' ) {
+                this._resize( el );
+            }
+        } );
+        this.element.addEventListener( events.PageFlip().type, event => {
+            const els = event.target.querySelectorAll( 'textarea' );
+            els.forEach( this._resize.bind( this ) );
+        } );
+
+        // https://github.com/OpenClinica/enketo-express-oc/issues/484
+        const textareaWidget = this;
+        setTimeout(function() {
+            textareas.forEach( textareaWidget._resize.bind( textareaWidget ) );    
+        }, 100);
+    }
+
+    _resize( el ) {
+        if ( el.scrollHeight > el.clientHeight && el.scrollHeight > this.defaultHeight ) {
+            // using height instead of min-height to allow user to resize smaller manually
+            el.style[ 'height' ] = `${el.scrollHeight}px`;
+            // for the Grid theme:
+            el.style[ 'flex' ] = 'auto';
+        }
+    }
+}
+
+export default TextareaWidget;


### PR DESCRIPTION
#484 

Hi @MartijnR, 
I confirmed that this issue only happens on enketo-express regardless of the theme(tested all available styles: formhub, grid, kobo, oc and plain). It's working fine on enketo-core so I'm not sure to put the fixed on there, that's why I override the widget on enketo-express-oc and put the fixed on that widget. The issue is about the widget timing on first loaded the scroll height and client height is not calculate correctly so the _resize is not fired. What do you think about it?
I use this [PDF1.xml.txt](https://github.com/OpenClinica/enketo-express-oc/files/6624595/PDF1.xml.txt) for testing

