### PR TITLE
fixed: OC: Opening form to query not working correctly for last item on form that have image map

### DIFF
--- a/widget/discrepancy-note/dn-widget.js
+++ b/widget/discrepancy-note/dn-widget.js
@@ -575,9 +575,27 @@ class Comment extends Widget {
         } );
 
         // https://github.com/OpenClinica/enketo-express-oc/issues/495
-        const maps = document.querySelectorAll( '.or-appearance-image-map' );
+        const maps = document.querySelectorAll( '.or-appearance-image-map' ),
+        root = this.element.closest( 'form' );
+        let count = 0;
+        const dn = this;
         if ( maps.length > 0 ) {
-            this._isMapsReady( maps, 0 );
+            const mutationObserver = new MutationObserver( mutations => {
+                mutations.forEach( mutation => {
+                    if ( mutation.attributeName === 'viewBox' && mutation.target.tagName === 'svg' ) {
+                        count++;
+                        if ( count === maps.length ) {
+                            dn._scrollToview();
+                            mutationObserver.disconnect();
+                        }
+                    }
+                });
+            });
+
+            mutationObserver.observe( root, {
+                attributes: true,
+                childList: true,
+                subtree: true });
         } else {
             this._scrollToview();
         }
@@ -592,23 +610,6 @@ class Comment extends Widget {
             } );
         } );
 
-    }
-
-    _isMapsReady( maps, counter ) {
-        let svg = maps[ counter ].querySelector( 'svg' );
-        setTimeout( () => {
-            if ( svg === null ) {
-                this._isMapsReady( maps, counter );
-            } else {
-                counter++;
-                if ( counter === maps.length ) {
-                    this._scrollToview();
-                } else {
-                    this._isMapsReady( maps, counter );
-                }
-            }
-
-        }, 200);
     }
 
     _scrollToview() {

--- a/widget/discrepancy-note/dn-widget.js
+++ b/widget/discrepancy-note/dn-widget.js
@@ -574,12 +574,10 @@ class Comment extends Widget {
             widget.style[ o[ 0 ] ] = o[ 1 ];
         } );
 
-        // Scroll directly to Query modal if not enough height for user to view the Query modal
-        // https://github.com/OpenClinica/enketo-express-oc/issues/378
-        if ( this.linkedQuestion.classList.contains( 'or-appearance-image-map' ) ) {
-            setTimeout( () => {
-                this._scrollToview();
-            }, 500 );
+        // https://github.com/OpenClinica/enketo-express-oc/issues/495
+        const maps = document.querySelectorAll( '.or-appearance-image-map' );
+        if ( maps.length > 0 ) {
+            this._isMapsReady( maps, 0 );
         } else {
             this._scrollToview();
         }
@@ -594,6 +592,23 @@ class Comment extends Widget {
             } );
         } );
 
+    }
+
+    _isMapsReady( maps, counter ) {
+        let svg = maps[ counter ].querySelector( 'svg' );
+        setTimeout( () => {
+            if ( svg === null ) {
+                this._isMapsReady( maps, counter );
+            } else {
+                counter++;
+                if ( counter === maps.length ) {
+                    this._scrollToview();
+                } else {
+                    this._isMapsReady( maps, counter );
+                }
+            }
+
+        }, 200);
     }
 
     _scrollToview() {

--- a/widget/discrepancy-note/dn-widget.js
+++ b/widget/discrepancy-note/dn-widget.js
@@ -575,17 +575,33 @@ class Comment extends Widget {
         } );
 
         // https://github.com/OpenClinica/enketo-express-oc/issues/495
-        const maps = document.querySelectorAll( '.or-appearance-image-map' ),
-        root = this.element.closest( 'form' );
+        this._mapChecker();
+
+        const closeButton = widget.querySelector( '.or-comment-widget__content__btn-close-x' );
+        const overlay = widget.querySelector( '.or-comment-widget__overlay--click-preventer' );
+        [ closeButton, overlay ].forEach( el => {
+            el.addEventListener( 'click', event => {
+                this._hideCommentModal( this.linkedQuestion );
+                event.preventDefault();
+                event.stopPropagation();
+            } );
+        } );
+
+    }
+
+    _mapChecker() {
+        const root = this.element.closest( 'form' ),
+        maps = Array.from( root.querySelectorAll( '.or-appearance-image-map' ) );
+        let ready = maps.every( map => map.querySelector( 'svg' ) );
+
         let count = 0;
-        const dn = this;
-        if ( maps.length > 0 ) {
+        if ( !ready ) {
             const mutationObserver = new MutationObserver( mutations => {
                 mutations.forEach( mutation => {
                     if ( mutation.attributeName === 'viewBox' && mutation.target.tagName === 'svg' ) {
                         count++;
                         if ( count === maps.length ) {
-                            dn._scrollToview();
+                            this._scrollToview();
                             mutationObserver.disconnect();
                         }
                     }
@@ -599,17 +615,6 @@ class Comment extends Widget {
         } else {
             this._scrollToview();
         }
-
-        const closeButton = widget.querySelector( '.or-comment-widget__content__btn-close-x' );
-        const overlay = widget.querySelector( '.or-comment-widget__overlay--click-preventer' );
-        [ closeButton, overlay ].forEach( el => {
-            el.addEventListener( 'click', event => {
-                this._hideCommentModal( this.linkedQuestion );
-                event.preventDefault();
-                event.stopPropagation();
-            } );
-        } );
-
     }
 
     _scrollToview() {


### PR DESCRIPTION
#495 

Hi @MartijnR  
This looks like a timing issue because the SVG from the image map is not fully loaded yet. I tried to use mutation tracker from dom-utils but it can't detect when SVG fully loaded, add event listener DOMContentLoaded also not working as expected. So I create the workaround like that, can you take a look at if the approach is acceptable or not?
Thanks