### PR TITLE
changed: remove 100% height on element when printing(workaround overlapping DN history)

### DIFF
--- a/app/views/styles/component/_print-oc.scss
+++ b/app/views/styles/component/_print-oc.scss
@@ -36,8 +36,6 @@
         &[role="comment"] {
             padding-top: 5px;
             padding-bottom: 10px;
-            height: 100% !important;
-
         }
     }
 


### PR DESCRIPTION
#527 
this style was added by me before to fix overlapping elements too(https://github.com/OpenClinica/enketo-express-oc/pull/292).  But because we add some delay on enketo-core ([PR](https://github.com/enketo/enketo-core/pull/862)) this style is not needed anymore.
