### PR TITLE
update:oc: update enketo refresh message(offline form)

### DIFF
--- a/locales/src/en/translation-additions.json
+++ b/locales/src/en/translation-additions.json
@@ -143,6 +143,14 @@
         "relevant": "An answer has changed to another question that requires this question to be hidden, but we cannot hide it while it has data. Please clear out the data or modify the dependent answers."
     },
     "alert": {
+        "appupdated": {
+            "heading": "App Updated!",
+            "msg": "Please refresh this webpage to use the form offline (ref: application)"
+        },
+        "formupdated": {
+            "heading": "Form Updated!",
+            "msg": "Please refresh this webpage to use the form offline (ref: definition)"
+        },
         "goto": {
             "irrelevant": "The item you are trying to access is currently hidden.",
             "invisible": "The item you are trying to access is not visible on the form.",


### PR DESCRIPTION
#566

Hi @MartijnR, I put the update on translation-additions.json, but I'm not sure why the alert message still has not changed on dev? Did I put it in the wrong place?
