### PR TITLE
fixed: do not show 'saving is disabled' on form previews, #647

### DIFF
--- a/public/js/src/module/controller-webform-oc.js
+++ b/public/js/src/module/controller-webform-oc.js
@@ -133,7 +133,10 @@ function init(formEl, data, loadErrors = []) {
                 form = new Form(formEl, data, formOptions);
                 replaceModelMediaSources(form, media);
 
-                fieldSubmissionQueue = new FieldSubmissionQueue();
+                fieldSubmissionQueue = new FieldSubmissionQueue({
+                    showStatus:
+                        settings.type !== 'view' && settings.type !== 'preview',
+                });
 
                 // Buffer inputupdate events (DURING LOAD ONLY), in order to eventually log these
                 // changes in the DN widget after it has been initalized

--- a/public/js/src/module/field-submission-queue.js
+++ b/public/js/src/module/field-submission-queue.js
@@ -22,7 +22,7 @@ const FIELDSUBMISSION_COMPLETE_URL = settings.enketoId
     : null;
 
 class FieldSubmissionQueue {
-    constructor() {
+    constructor(options = { showStatus: true }) {
         this.submissionQueue = {};
         this.submissionOngoing = null;
         this.lastAdded = {};
@@ -63,19 +63,21 @@ class FieldSubmissionQueue {
                 }
             },
             update(status) {
-                this.statusElements.forEach((element) => {
-                    element.classList.remove([
-                        'ongoing',
-                        'success',
-                        'error',
-                        'fail',
-                    ]);
-                    element.classList.add(status);
-                    element.dataset.i18n = `fieldsubmission.feedback.${status}`;
-                    element.textContent = t(
-                        `fieldsubmission.feedback.${status}`
-                    );
-                });
+                if (options.showStatus) {
+                    this.statusElements.forEach((element) => {
+                        element.classList.remove([
+                            'ongoing',
+                            'success',
+                            'error',
+                            'fail',
+                        ]);
+                        element.classList.add(status);
+                        element.dataset.i18n = `fieldsubmission.feedback.${status}`;
+                        element.textContent = t(
+                            `fieldsubmission.feedback.${status}`
+                        );
+                    });
+                }
             },
         };
 


### PR DESCRIPTION
Closes #647

#### I have verified this PR works with

- previews
- readonly views loading a record
- regular fieldsubmission views
- regular fieldsubmission views with a loading error leading to the 'disabled' message