### PR TITLE
fixed: regression due to code splitting in esbuild

### DIFF
--- a/config/build.js
+++ b/config/build.js
@@ -23,6 +23,6 @@ module.exports = /** @satisfies {import('esbuild').BuildOptions} */ ({
     minify: true,
     outdir: path.resolve(cwd, './public/js/build'),
     sourcemap: true,
-    splitting: true,
+    splitting: false,
     target: ['chrome89', 'edge89', 'firefox90', 'safari13'],
 });


### PR DESCRIPTION
Closes #695

@kkrumlian, I think it is best to first merge https://github.com/OpenClinica/enketo-express-oc/pull/697 because for some reason those 6.2.0 merge commits are not showing up in this PR (event though I built it on top of the 6.2.0 branch).

Update: it actually has a conflict. My guess is the conflict will be go away once #697 is merged.
